### PR TITLE
Update sifter.js

### DIFF
--- a/sifter.js
+++ b/sifter.js
@@ -58,7 +58,7 @@
 			if (this.settings.diacritics) {
 				for (letter in DIACRITICS) {
 					if (DIACRITICS.hasOwnProperty(letter)) {
-						regex = regex.replace(new RegExp(letter, 'g'), DIACRITICS[letter]);
+						regex = regex.replace(new RegExp(DIACRITICS[letter], 'g'), letter );
 					}
 				}
 			}


### PR DESCRIPTION
corrected a minor bug: diacritics regex and substitution string were inverted
