### PR TITLE
Add support for iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"
 before_script:
   - make
 script:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cardinal": "0.4.x",
     "async": "0.2.x",
     "humanize": "0.0.x",
-    "microtime": "~1.2.0",
+    "microtime": "~1.4.2",
     "node-csv": "https://github.com/voodootikigod/node-csv/tarball/master"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds testing on `0.12` and `iojs` to Travis CI and updates `microtime` to support installing on both those versions. Without updating `microtime`, `npm install` fails on 0.12 and iojs.