### PR TITLE
Nested properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Performs a search for `query` with the provided `options`.
 		<td valign="top">string</td>
 		<td valign="top">Determines how multiple search terms are joined ("and" or "or").</td>
 	</tr>
+	<tr>
+		<td valign="top">"nesting"</td>
+		<td valign="top">boolean</td>
+		<td valign="top">If <code>true</code>, nested fields will be available for search and sort using dot-notation to reference them.<br>ex:<code>nested.property</code><br><em>Warning: can reduce performances</em></td>
+	</tr>
 </table>
 
 ## CLI

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Sifter is a client and server-side library (via [UMD](https://github.com/umdjs/u
 * **Supports díåcritîçs.**<br>For example, if searching for "montana" and an item in the set has a value of "montaña", it will still be matched. Sorting will also play nicely with diacritics.
 * **Smart scoring.**<br>Items are scored / sorted intelligently depending on where a match is found in the string (how close to the beginning) and what percentage of the string matches.
 * **Multi-field sorting.**<br>When scores aren't enough to go by – like when getting results for an empty query – it can sort by one or more fields. For example, sort by a person's first name and last name without actually merging the properties to a single string.
+* **Nested properties.**<br>Allows to search and sort on nested properties so you can perform search on complex objects without flattening them simply by using dot-notation to reference fields (ie. `nested.property`).
 
 ```sh
 $ npm install sifter # node.js

--- a/lib/sifter.js
+++ b/lib/sifter.js
@@ -223,7 +223,10 @@
 		 */
 		get_field = function(name, result) {
 			if (name === '$score') return result.score;
-			return self.items[result.id][name];
+		    var names = name.split("."),
+		    	obj = self.items[result.id];
+		    while(names.length && (obj = obj[names.shift()]));
+		    return obj;
 		};
 
 		// parse options

--- a/lib/sifter.js
+++ b/lib/sifter.js
@@ -114,13 +114,14 @@
 	 * @returns {function}
 	 */
 	Sifter.prototype.getScoreFunction = function(search, options) {
-		var self, fields, tokens, token_count;
+		var self, fields, tokens, token_count, nesting;
 
 		self        = this;
 		search      = self.prepareSearch(search, options);
 		tokens      = search.tokens;
 		fields      = search.options.fields;
 		token_count = tokens.length;
+		nesting     = search.options.nesting;
 
 		/**
 		 * Calculates how close of a match the
@@ -157,12 +158,12 @@
 			}
 			if (field_count === 1) {
 				return function(token, data) {
-					return scoreValue(getattr(data, fields[0]), token);
+					return scoreValue(getattr(data, fields[0], nesting), token);
 				};
 			}
 			return function(token, data) {
 				for (var i = 0, sum = 0; i < field_count; i++) {
-					sum += scoreValue(getattr(data, fields[i]), token);
+					sum += scoreValue(getattr(data, fields[i], nesting), token);
 				}
 				return sum / field_count;
 			};
@@ -223,7 +224,7 @@
 		 */
 		get_field = function(name, result) {
 			if (name === '$score') return result.score;
-			return getattr(self.items[result.id], name);
+			return getattr(self.items[result.id], name, options.nesting);
 		};
 
 		// parse options
@@ -414,12 +415,14 @@
 
 	/**
 	 * A property getter resolving dot-notation
-	 * @param  {Object} obj  The root object to fetch property on
-	 * @param  {String} name The optionnaly dotted property name to fetch
-	 * @return {Object}      The resolved property value
+	 * @param  {Object}  obj     The root object to fetch property on
+	 * @param  {String}  name    The optionally dotted property name to fetch
+	 * @param  {Boolean} nesting Handle nesting or not
+	 * @return {Object}          The resolved property value
 	 */
-	var getattr = function(obj, name) {
+	var getattr = function(obj, name, nesting) {
 	    if (!obj || !name) return;
+	    if (!nesting) return obj[name];
 	    var names = name.split(".");
 	    while(names.length && (obj = obj[names.shift()]));
 	    return obj;

--- a/lib/sifter.js
+++ b/lib/sifter.js
@@ -157,12 +157,12 @@
 			}
 			if (field_count === 1) {
 				return function(token, data) {
-					return scoreValue(data[fields[0]], token);
+					return scoreValue(getattr(data, fields[0]), token);
 				};
 			}
 			return function(token, data) {
 				for (var i = 0, sum = 0; i < field_count; i++) {
-					sum += scoreValue(data[fields[i]], token);
+					sum += scoreValue(getattr(data, fields[i]), token);
 				}
 				return sum / field_count;
 			};
@@ -223,10 +223,7 @@
 		 */
 		get_field = function(name, result) {
 			if (name === '$score') return result.score;
-		    var names = name.split("."),
-		    	obj = self.items[result.id];
-		    while(names.length && (obj = obj[names.shift()]));
-		    return obj;
+			return getattr(self.items[result.id], name);
 		};
 
 		// parse options
@@ -413,6 +410,19 @@
 			}
 		}
 		return a;
+	};
+
+	/**
+	 * A property getter resolving dot-notation
+	 * @param  {Object} obj  The root object to fetch property on
+	 * @param  {String} name The optionnaly dotted property name to fetch
+	 * @return {Object}      The resolved property value
+	 */
+	var getattr = function(obj, name) {
+	    if (!obj || !name) return;
+	    var names = name.split(".");
+	    while(names.length && (obj = obj[names.shift()]));
+	    return obj;
 	};
 
 	var trim = function(str) {

--- a/test/api.js
+++ b/test/api.js
@@ -117,7 +117,7 @@ describe('Sifter', function() {
 
 	});
 
-	describe('#prepareSeach()', function() {
+	describe('#prepareSearch()', function() {
 
 		it('should normalize options', function() {
 			var sifter = new Sifter([{field: 'a'}, {}]);
@@ -306,6 +306,20 @@ describe('Sifter', function() {
 				});
 				assert.equal(result.items[0].id, 1);
 				assert.equal(result.items[1].id, 0);
+			});
+			it('should work with nested fields', function() {
+				var sifter = new Sifter([
+					{fields: {nested: 'aaa'}},
+					{fields: {nested: 'add'}},
+					{fields: {nested: 'abb'}}
+				]);
+				var result = sifter.search('', {
+					fields: [],
+					sort: {field: 'fields.nested'}
+				});
+				assert.equal(result.items[0].id, 0);
+				assert.equal(result.items[1].id, 2);
+				assert.equal(result.items[2].id, 1);
 			});
 		});
 

--- a/test/api.js
+++ b/test/api.js
@@ -178,6 +178,7 @@ describe('Sifter', function() {
 			]);
 			var result = sifter.search('aaa', {
 				fields: 'fields.nested',
+				nesting: true
 			});
 
 			assert.equal(result.items.length, 1);
@@ -329,7 +330,8 @@ describe('Sifter', function() {
 				]);
 				var result = sifter.search('', {
 					fields: [],
-					sort: {field: 'fields.nested'}
+					sort: {field: 'fields.nested'},
+					nesting: true
 				});
 				assert.equal(result.items[0].id, 0);
 				assert.equal(result.items[1].id, 2);

--- a/test/api.js
+++ b/test/api.js
@@ -170,6 +170,20 @@ describe('Sifter', function() {
 			assert.equal(result.items[0].id, 0);
 		});
 
+		it('should allow to search nested fields', function() {
+			var sifter = new Sifter([
+				{fields: {nested: 'aaa'}},
+				{fields: {nested: 'add'}},
+				{fields: {nested: 'abb'}}
+			]);
+			var result = sifter.search('aaa', {
+				fields: 'fields.nested',
+			});
+
+			assert.equal(result.items.length, 1);
+			assert.equal(result.items[0].id, 0);
+		});
+
 		describe('sorting', function() {
 			it('should respect "sort_empty" option when query absent', function() {
 				var sifter = new Sifter([


### PR DESCRIPTION
This pull request add support for searching and sorting on nested properties using dot-notation when declaring fields (ie. `nested.property`).

I tried updating the documentation but I'm not sure on where to put this.

This pull request fix #26.