### PR TITLE
Change microtime to be optional dependency with fallback to milliseconds

### DIFF
--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -18,8 +18,18 @@ process.chdir(__dirname);
 
 var fs        = require('fs');
 var humanize  = require('humanize');
-var microtime = require('microtime');
 var Sifter    = require('../lib/sifter');
+var microtime;
+
+try {
+	microtime = require('microtime');
+} catch(error) {
+	microtime = {
+		now: function now() {
+			return +new Date();
+		}
+	};
+}
 
 var measure_time = function(fn) {
 	var start, end;

--- a/bin/sifter.js
+++ b/bin/sifter.js
@@ -25,9 +25,19 @@ var async     = require('async');
 var csv       = require('node-csv');
 var Stream    = require('stream');
 var humanize  = require('humanize');
-var microtime = require('microtime');
 var Sifter    = require('../lib/sifter');
 var highlight = function(obj) { return cardinal.highlight(JSON.stringify(obj), {json: true}); };
+var microtime;
+
+try {
+	microtime = require('microtime');
+} catch(error) {
+	microtime = {
+		now: function now() {
+			return +new Date();
+		}
+	};
+}
 
 var raw, data, result, t_start, t_end;
 var argv = optimist

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "cardinal": "0.4.x",
     "async": "0.2.x",
     "humanize": "0.0.x",
-    "microtime": "~1.4.2",
     "node-csv": "https://github.com/voodootikigod/node-csv/tarball/master"
   },
   "devDependencies": {
@@ -39,6 +38,9 @@
     "coveralls": "2.3.x",
     "uglify-js": "2.4.x",
     "istanbul": "0.1.x"
+  },
+  "optionalDependencies": {
+    "microtime": "~1.4.2"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Hi there. As the microtime dependency is cause a lot of troubles on systems where Python is not installed, and the fact that it's only used to show more accurate timings, it should be made an optional dependency. In the PR the require is surrounded with a try catch block and a fallback to regular milliseconds (with Date) is used.