### PR TITLE
Avoid Errors in Internet Explorer 8 if jQuery isn't loaded

### DIFF
--- a/lib/sifter.js
+++ b/lib/sifter.js
@@ -420,7 +420,7 @@
 		return (str + '').replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1');
 	};
 
-	var is_array = Array.isArray || ($ && $.isArray) || function(object) {
+	var is_array = Array.isArray || (typeof $ !== 'undefined' && $.isArray) || function(object) {
 		return Object.prototype.toString.call(object) === '[object Array]';
 	};
 


### PR DESCRIPTION
If jQuery is not loaded before sifter this line previously failed in
Internet Explorer 8 with the message "'$' is undefined" instead of using
the fallback function.