### PR TITLE
Bump microtime to fix installing on Node v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "istanbul": "0.1.x"
   },
   "optionalDependencies": {
-    "microtime": "2.0.x"
+    "microtime": "^2.1.0"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Bump microtime to 2.1.x to get this fix: https://github.com/wadey/node-microtime/issues/42

Fixes `error: no type named 'GCEpilogueCallback' in 'v8::Isolate'` when installing `nan` requirement of `microtime` requirement in Node 6.