### PR TITLE
Change csv dependency to use an npm-available parser

### DIFF
--- a/bin/sifter.js
+++ b/bin/sifter.js
@@ -22,7 +22,7 @@ var fs        = require('fs');
 var optimist  = require('optimist');
 var cardinal  = require('cardinal');
 var async     = require('async');
-var csv       = require('node-csv');
+var csv       = require('csv-parse');
 var Stream    = require('stream');
 var humanize  = require('humanize');
 var Sifter    = require('../lib/sifter');
@@ -98,11 +98,13 @@ var step_parse = function(callback) {
 
 	// csv
 	data = [];
-	csv.parse(raw, {headers: true}, function(line) {
-		if (Array.isArray(line)) return;
-		data.push(line);
+	csv(raw, {columns: true}, function(err, parsed) {
+		parsed.forEach(function(line) {
+			if (Array.isArray(line)) return;
+			data.push(line);
+		});
+		callback();
 	});
-	callback();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cardinal": "0.4.x",
     "async": "0.2.x",
     "humanize": "0.0.x",
-    "node-csv": "git://github.com/voodootikigod/node-csv"
+    "csv-parse": "^1.1.7"
   },
   "devDependencies": {
     "mocha": "1.12.x",


### PR DESCRIPTION
Hey @brianreavis,

We have had some issues lately with the way this csv dependency works. Especially behind proxies and what not. This just changes the dependency to use another parser that is accessible through npm.

I ran the tests, they were fine and I got the same results when running the csv commands you have in your README.md.

Let me know if I need to change anything here.