### PR TITLE
add .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 .git*
 benchmark/
 test/
+.babelrc


### PR DESCRIPTION
Hi,

I'm encountering a problem using sifter in a react-native project: the .babelrc is (strangely) handled by the react-native bundler, and try to load the babel-plugin-add-module-export (that I don't have). See this issue for context: https://github.com/facebook/react-native/issues/4062

Thanks !