### PR TITLE
Update node test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
-  - "6"
+  - "10"
+  - "12"
 before_script:
   - make
 script:


### PR DESCRIPTION
- Build breaks in node 4 (https://travis-ci.org/brianreavis/sifter.js/jobs/634425454).
- 6 is no longer maintained.
- Would suggest testing in 10 and 12 instead.